### PR TITLE
🎨Typing issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,4 @@ dmypy.json
 # vscode settings
 .vscode/
 
-src/_your_package_version.py
+src/_error_handler_version.py

--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, force=True)
 logger = logging.root
 op = aiostream.stream.iterate(range(10))
 
+
 def log_error(error: Exception, num: int):
     """Only log error and reraise it"""
     logger.error("double_only_odd_nums_except_5 failed for input %d. ", num)
     raise error
+
 
 @error_handler.decorator(on_error=log_error)
 async def double_only_odd_nums_except_5(num: int) -> int:
@@ -59,12 +61,15 @@ async def double_only_odd_nums_except_5(num: int) -> int:
         num *= 2
     return num
 
+
 def catch_value_errors(error: Exception, _: int):
     if not isinstance(error, ValueError):
         raise error
 
+
 def log_success(result_num: int, provided_num: int):
     logger.info("Success: %d -> %d", provided_num, result_num)
+
 
 op = op | error_handler.pipe.map(
     double_only_odd_nums_except_5,

--- a/src/error_handler/__init__.py
+++ b/src/error_handler/__init__.py
@@ -7,17 +7,9 @@ import importlib
 from typing import TYPE_CHECKING
 
 from .context_manager import context_manager
-from .decorator import decorator, retry_on_error
-from .types import (
-    ERRORED,
-    UNSET,
-    AsyncFunctionType,
-    ErroredType,
-    FunctionType,
-    SecuredAsyncFunctionType,
-    SecuredFunctionType,
-    UnsetType,
-)
+from .decorator import decorator, decorator_as_result, retry_on_error
+from .result import NegativeResult, PositiveResult, ResultType
+from .types import UNSET, AsyncFunctionType, FunctionType, SecuredAsyncFunctionType, SecuredFunctionType, UnsetType
 
 if TYPE_CHECKING:
     from . import pipe, stream

--- a/src/error_handler/callback.py
+++ b/src/error_handler/callback.py
@@ -102,7 +102,9 @@ class ErrorCallback(Callback[_P, _T]):
     signature.
     """
 
-    _CALLBACK_ERROR_PARAM = inspect.Parameter("error", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Exception)
+    _CALLBACK_ERROR_PARAM = inspect.Parameter(
+        "error", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=BaseException
+    )
 
     @classmethod
     def from_callable(

--- a/src/error_handler/context_manager.py
+++ b/src/error_handler/context_manager.py
@@ -15,7 +15,7 @@ from .types import UnsetType
 def context_manager(
     *,
     on_success: Callable[[], Any] | None = None,
-    on_error: Callable[[Exception], Any] | None = None,
+    on_error: Callable[[BaseException], Any] | None = None,
     on_finalize: Callable[[], Any] | None = None,
     suppress_recalling_on_error: bool = True,
 ) -> Iterator[Catcher[UnsetType]]:

--- a/src/error_handler/context_manager.py
+++ b/src/error_handler/context_manager.py
@@ -13,6 +13,7 @@ from .types import UnsetType
 # pylint: disable=unsubscriptable-object
 @contextmanager
 def context_manager(
+    *,
     on_success: Callable[[], Any] | None = None,
     on_error: Callable[[Exception], Any] | None = None,
     on_finalize: Callable[[], Any] | None = None,

--- a/src/error_handler/context_manager.py
+++ b/src/error_handler/context_manager.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from typing import Any, Callable, Iterator
 
 from .callback import Callback, ErrorCallback
-from .core import Catcher
+from .core import Catcher, ContextCatcher
 from .types import UnsetType
 
 
@@ -28,7 +28,7 @@ def context_manager(
     If suppress_recalling_on_error is True, the on_error callable will not be called if the error were already
     caught by a previous catcher.
     """
-    catcher = Catcher[UnsetType](
+    catcher = ContextCatcher(
         Callback.from_callable(on_success, return_type=Any) if on_success is not None else None,
         ErrorCallback.from_callable(on_error, return_type=Any) if on_error is not None else None,
         Callback.from_callable(on_finalize, return_type=Any) if on_finalize is not None else None,

--- a/src/error_handler/decorator.py
+++ b/src/error_handler/decorator.py
@@ -7,20 +7,12 @@ import functools
 import inspect
 import logging
 import time
-from typing import Any, Callable, Concatenate, Generator, ParamSpec, TypeGuard, TypeVar, cast
+from typing import Any, Callable, Concatenate, Generator, ParamSpec, Protocol, TypeGuard, TypeVar, cast, overload
 
 from .callback import Callback, ErrorCallback, SuccessCallback
 from .core import Catcher
 from .result import CallbackResultType, PositiveResult, ResultType
-from .types import (
-    ERRORED,
-    AsyncFunctionType,
-    ErroredType,
-    FunctionType,
-    SecuredAsyncFunctionType,
-    SecuredFunctionType,
-    UnsetType,
-)
+from .types import UNSET, AsyncFunctionType, FunctionType, SecuredAsyncFunctionType, SecuredFunctionType, UnsetType
 
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
@@ -35,16 +27,66 @@ def iscoroutinefunction(
     return asyncio.iscoroutinefunction(callable_)
 
 
+# pylint: disable=too-few-public-methods
+class SecureDecorator(Protocol[_P, _T]):
+    """
+    This protocol represents a decorator that secures a callable and returns a ResultType[T].
+    """
+
+    @overload
+    def __call__(  # type: ignore[overload-overlap]
+        # This error happens, because Callable[..., Awaitable[T]] is a subtype of Callable[..., T] and
+        # therefore the overloads are overlapping. This leads to problems with the type checker if you use it like this:
+        #
+        # async def some_coroutine_function() -> None: ...
+        # callable_to_secure: FunctionType[_P, _T] = some_coroutine_function
+        # reveal_type(decorator(callable_to_secure))
+        #
+        # Revealed type is 'SecuredAsyncFunctionType[_P, _T]' but mypy will think it is 'SecuredFunctionType[_P, _T]'.
+        # Since it is not possible to 'negate' types (e.g. something like 'Callable[..., T \ Awaitable[T]]'),
+        # we have no other choice than to ignore this error. Anyway, it should be fine if you are plainly decorating
+        # your functions, so it's ok.
+        # Reference: https://stackoverflow.com/a/74567241/21303427
+        self,
+        callable_to_secure: AsyncFunctionType[_P, _T],
+    ) -> SecuredAsyncFunctionType[_P, _T]: ...
+
+    @overload
+    def __call__(self, callable_to_secure: FunctionType[_P, _T]) -> SecuredFunctionType[_P, _T]: ...
+
+    def __call__(
+        self, callable_to_secure: FunctionType[_P, _T] | AsyncFunctionType[_P, _T]
+    ) -> SecuredFunctionType[_P, _T] | SecuredAsyncFunctionType[_P, _T]: ...
+
+
+# pylint: disable=too-few-public-methods
+class Decorator(Protocol[_P, _T]):
+    """
+    This protocol represents a decorator that secures a callable but does not change the return type.
+    """
+
+    @overload
+    def __call__(  # type: ignore[overload-overlap]
+        self,
+        callable_to_secure: AsyncFunctionType[_P, _T],
+    ) -> AsyncFunctionType[_P, _T]: ...
+
+    @overload
+    def __call__(self, callable_to_secure: FunctionType[_P, _T]) -> FunctionType[_P, _T]: ...
+
+    def __call__(
+        self,
+        callable_to_secure: FunctionType[_P, _T] | AsyncFunctionType[_P, _T],
+    ) -> FunctionType[_P, _T] | AsyncFunctionType[_P, _T]: ...
+
+
 # pylint: disable=too-many-arguments
-def decorator(
+def decorator_as_result(
     on_success: Callable[Concatenate[_T, _P], Any] | None = None,
     on_error: Callable[Concatenate[Exception, _P], Any] | None = None,
     on_finalize: Callable[_P, Any] | None = None,
-    on_error_return_always: _T | ErroredType = ERRORED,
     suppress_recalling_on_error: bool = True,
-) -> Callable[
-    [FunctionType[_P, _T] | AsyncFunctionType[_P, _T]], SecuredFunctionType[_P, _T] | SecuredAsyncFunctionType[_P, _T]
-]:
+) -> SecureDecorator[_P, _T]:
     """
     This decorator secures a callable (sync or async) and handles its errors.
     If the callable raises an error, the on_error callback will be called and the value if on_error_return_always
@@ -58,6 +100,14 @@ def decorator(
     """
     # pylint: disable=unsubscriptable-object
 
+    @overload
+    def decorator_inner(  # type: ignore[overload-overlap] # See above
+        callable_to_secure: AsyncFunctionType[_P, _T],
+    ) -> SecuredAsyncFunctionType[_P, _T]: ...
+
+    @overload
+    def decorator_inner(callable_to_secure: FunctionType[_P, _T]) -> SecuredFunctionType[_P, _T]: ...
+
     def decorator_inner(
         callable_to_secure: FunctionType[_P, _T] | AsyncFunctionType[_P, _T]
     ) -> SecuredFunctionType[_P, _T] | SecuredAsyncFunctionType[_P, _T]:
@@ -66,30 +116,27 @@ def decorator(
             SuccessCallback.from_callable(on_success, sig, return_type=Any) if on_success is not None else None,
             ErrorCallback.from_callable(on_error, sig, return_type=Any) if on_error is not None else None,
             Callback.from_callable(on_finalize, sig, return_type=Any) if on_finalize is not None else None,
-            on_error_return_always,
             suppress_recalling_on_error,
         )
         if iscoroutinefunction(callable_to_secure):
 
             @functools.wraps(callable_to_secure)
-            async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T | ErroredType:
+            async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> ResultType[_T]:
                 result = await catcher.secure_await(callable_to_secure(*args, **kwargs))
                 catcher.handle_result_and_call_callbacks(result, *args, **kwargs)
-                assert not isinstance(result.result, UnsetType), "Internal error: result is unset"
-                return result.result
+                return result
 
         else:
 
             @functools.wraps(callable_to_secure)
-            def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T | ErroredType:
+            def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> ResultType[_T]:
                 result = catcher.secure_call(
                     callable_to_secure,  # type: ignore[arg-type]
                     *args,
                     **kwargs,
                 )
                 catcher.handle_result_and_call_callbacks(result, *args, **kwargs)
-                assert not isinstance(result.result, UnsetType), "Internal error: result is unset"
-                return result.result
+                return result
 
         return_func = cast(SecuredFunctionType[_P, _T] | SecuredAsyncFunctionType[_P, _T], wrapper)
         return_func.__catcher__ = catcher
@@ -110,9 +157,7 @@ def retry_on_error(
     on_fail: Callable[Concatenate[Exception, int, _P], Any] | None = None,
     on_finalize: Callable[Concatenate[int, _P], Any] | None = None,
     logger: logging.Logger = logging.getLogger(__name__),
-) -> Callable[
-    [FunctionType[_P, _T] | AsyncFunctionType[_P, _T]], SecuredFunctionType[_P, _T] | SecuredAsyncFunctionType[_P, _T]
-]:
+) -> Decorator[_P, _T]:
     """
     This decorator retries a callable (sync or async) on error.
     The retry_stepping_func is called with the retry count and should return the time to wait until the next retry.
@@ -126,7 +171,7 @@ def retry_on_error(
 
     def decorator_inner(
         callable_to_secure: FunctionType[_P, _T] | AsyncFunctionType[_P, _T]
-    ) -> SecuredFunctionType[_P, _T] | SecuredAsyncFunctionType[_P, _T]:
+    ) -> FunctionType[_P, _T] | AsyncFunctionType[_P, _T]:
         sig = inspect.signature(callable_to_secure)
         sig = sig.replace(
             parameters=[
@@ -183,7 +228,6 @@ def retry_on_error(
 
         def handle_result_and_call_callbacks(result: ResultType[_T], *args: _P.args, **kwargs: _P.kwargs) -> _T:
             if isinstance(result, PositiveResult):
-                assert not isinstance(result.result, UnsetType), "Internal error: result is unset"
                 catcher_retrier.handle_success_case(
                     result.result,
                     retry_count,
@@ -238,9 +282,57 @@ def retry_on_error(
                 result = catcher_retrier.secure_call(retry_function_sync, *args, **kwargs)
                 return handle_result_and_call_callbacks(result, *args, **kwargs)
 
-        return_func = cast(SecuredFunctionType[_P, _T] | SecuredAsyncFunctionType[_P, _T], wrapper)
-        return_func.__catcher__ = catcher_retrier
-        return_func.__original_callable__ = callable_to_secure
+        return_func = cast(FunctionType[_P, _T] | AsyncFunctionType[_P, _T], wrapper)
+        return_func.__catcher__ = catcher_retrier  # type: ignore[union-attr]
+        return_func.__original_callable__ = callable_to_secure  # type: ignore[union-attr]
         return return_func
 
-    return decorator_inner
+    return decorator_inner  # type: ignore[return-value]
+
+
+def decorator(
+    *,
+    on_success: Callable[Concatenate[_T, _P], Any] | None = None,
+    on_error: Callable[Concatenate[Exception, _P], Any] | None = None,
+    on_finalize: Callable[_P, Any] | None = None,
+    suppress_recalling_on_error: bool = True,
+    on_error_return_always: _T | UnsetType = UNSET,
+) -> Decorator[_P, _T]:
+    """
+    Returns a callback that converts the result of a secured function back to the original return type.
+    To make this work, you need to define which value should be returned in error cases.
+    Otherwise, if the secured function returns an error result, the error will be raised.
+    """
+
+    def decorator_inner(
+        func: FunctionType[_P, _T] | AsyncFunctionType[_P, _T]
+    ) -> FunctionType[_P, _T] | AsyncFunctionType[_P, _T]:
+        secured_func = decorator_as_result(
+            on_success=on_success,
+            on_error=on_error,
+            on_finalize=on_finalize,
+            suppress_recalling_on_error=suppress_recalling_on_error,
+        )(func)
+
+        def handle_result(result: ResultType[_T]) -> _T:
+            if isinstance(result, PositiveResult):
+                return result.result
+            if isinstance(on_error_return_always, UnsetType):
+                raise result.error
+            return on_error_return_always
+
+        if iscoroutinefunction(secured_func):
+
+            @functools.wraps(secured_func)
+            async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+                return handle_result(await secured_func(*args, **kwargs))
+
+        else:
+
+            @functools.wraps(secured_func)
+            def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+                return handle_result(secured_func(*args, **kwargs))  # type: ignore[arg-type]
+
+        return cast(FunctionType[_P, _T] | AsyncFunctionType[_P, _T], wrapper)
+
+    return decorator_inner  # type: ignore[return-value]

--- a/src/error_handler/decorator.py
+++ b/src/error_handler/decorator.py
@@ -84,7 +84,7 @@ class Decorator(Protocol[_P, _T]):
 def decorator_as_result(
     *,
     on_success: Callable[Concatenate[_T, _P], Any] | None = None,
-    on_error: Callable[Concatenate[Exception, _P], Any] | None = None,
+    on_error: Callable[Concatenate[BaseException, _P], Any] | None = None,
     on_finalize: Callable[_P, Any] | None = None,
     suppress_recalling_on_error: bool = True,
 ) -> SecureDecorator[_P, _T]:
@@ -150,13 +150,13 @@ def decorator_as_result(
 # pylint: disable=too-many-arguments, too-many-locals
 def retry_on_error(
     *,
-    on_error: Callable[Concatenate[Exception, int, _P], bool],
+    on_error: Callable[Concatenate[BaseException, int, _P], bool],
     retry_stepping_func: Callable[[int], float] = lambda retry_count: 1.71**retry_count,
     # <-- with max_retries = 10 the whole decorator may wait up to 5 minutes.
     # because sum(1.71seconds**i for i in range(10)) == 5minutes
     max_retries: int = 10,
     on_success: Callable[Concatenate[_T, int, _P], Any] | None = None,
-    on_fail: Callable[Concatenate[Exception, int, _P], Any] | None = None,
+    on_fail: Callable[Concatenate[BaseException, int, _P], Any] | None = None,
     on_finalize: Callable[Concatenate[int, _P], Any] | None = None,
     logger: logging.Logger = logging.getLogger(__name__),
 ) -> Decorator[_P, _T]:
@@ -181,13 +181,13 @@ def retry_on_error(
                 *sig.parameters.values(),
             ],
         )
-        on_error_callback: ErrorCallback[Concatenate[Exception, int, _P], bool] = ErrorCallback.from_callable(
+        on_error_callback: ErrorCallback[Concatenate[BaseException, int, _P], bool] = ErrorCallback.from_callable(
             on_error, sig, return_type=bool
         )
         on_success_callback: SuccessCallback[Concatenate[_T, int, _P], Any] | None = (
             SuccessCallback.from_callable(on_success, sig, return_type=Any) if on_success is not None else None
         )
-        on_fail_callback: ErrorCallback[Concatenate[Exception, int, _P], Any] | None = (
+        on_fail_callback: ErrorCallback[Concatenate[BaseException, int, _P], Any] | None = (
             ErrorCallback.from_callable(on_fail, sig, return_type=Any) if on_fail is not None else None
         )
         on_finalize_callback: Callback[Concatenate[int, _P], Any] | None = (
@@ -295,7 +295,7 @@ def retry_on_error(
 def decorator(
     *,
     on_success: Callable[Concatenate[_T, _P], Any] | None = None,
-    on_error: Callable[Concatenate[Exception, _P], Any] | None = None,
+    on_error: Callable[Concatenate[BaseException, _P], Any] | None = None,
     on_finalize: Callable[_P, Any] | None = None,
     suppress_recalling_on_error: bool = True,
     on_error_return_always: _T | UnsetType = UNSET,

--- a/src/error_handler/decorator.py
+++ b/src/error_handler/decorator.py
@@ -82,6 +82,7 @@ class Decorator(Protocol[_P, _T]):
 
 # pylint: disable=too-many-arguments
 def decorator_as_result(
+    *,
     on_success: Callable[Concatenate[_T, _P], Any] | None = None,
     on_error: Callable[Concatenate[Exception, _P], Any] | None = None,
     on_finalize: Callable[_P, Any] | None = None,
@@ -148,6 +149,7 @@ def decorator_as_result(
 
 # pylint: disable=too-many-arguments, too-many-locals
 def retry_on_error(
+    *,
     on_error: Callable[Concatenate[Exception, int, _P], bool],
     retry_stepping_func: Callable[[int], float] = lambda retry_count: 1.71**retry_count,
     # <-- with max_retries = 10 the whole decorator may wait up to 5 minutes.

--- a/src/error_handler/result.py
+++ b/src/error_handler/result.py
@@ -4,9 +4,11 @@ This module contains classes to encapsulate some information about the result of
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, Generic, TypeAlias
+from typing import Any, Generic, TypeAlias, TypeVar
 
-from error_handler.types import UNSET, ErroredType, T, UnsetType
+from error_handler.types import UNSET
+
+T = TypeVar("T")
 
 
 class CallbackResultType(StrEnum):
@@ -59,7 +61,7 @@ class PositiveResult(Generic[T]):
     Represents a successful result.
     """
 
-    result: T | UnsetType
+    result: T
 
 
 @dataclass(frozen=True)
@@ -68,7 +70,6 @@ class NegativeResult(Generic[T]):
     Represents an errored result.
     """
 
-    result: T | ErroredType
     error: BaseException
 
 

--- a/src/error_handler/stream.py
+++ b/src/error_handler/stream.py
@@ -79,8 +79,8 @@ if IS_AIOSTREAM_INSTALLED:
         )
         result_values: AsyncIterator[U] = aiostream.stream.map.raw(
             positive_results,
-            lambda result: (
-                result.result if isinstance(result, PositiveResult) else result  # type: ignore[arg-type, misc]
+            lambda result: (  # type: ignore[arg-type, misc]
+                result.result if isinstance(result, PositiveResult) else result
             ),
         )
         return result_values

--- a/src/error_handler/stream.py
+++ b/src/error_handler/stream.py
@@ -29,7 +29,7 @@ if IS_AIOSTREAM_INSTALLED:
         ordered: bool = True,
         task_limit: int | None = None,
         on_success: Callable[[U, T], Any] | None = None,
-        on_error: Callable[[Exception, T], Any] | None = None,
+        on_error: Callable[[BaseException, T], Any] | None = None,
         on_finalize: Callable[[T], Any] | None = None,
         wrap_secured_function: bool = False,
         suppress_recalling_on_error: bool = True,

--- a/src/error_handler/stream.py
+++ b/src/error_handler/stream.py
@@ -6,9 +6,10 @@ import logging
 import sys
 from typing import Any, AsyncIterable, AsyncIterator, Callable
 
+from . import NegativeResult, PositiveResult, ResultType
 from ._extra import IS_AIOSTREAM_INSTALLED
-from .decorator import decorator
-from .types import ERRORED, AsyncFunctionType, FunctionType, SecuredAsyncFunctionType, SecuredFunctionType, is_secured
+from .decorator import decorator_as_result
+from .types import AsyncFunctionType, FunctionType, SecuredAsyncFunctionType, SecuredFunctionType, is_secured
 
 if IS_AIOSTREAM_INSTALLED:
     import aiostream
@@ -41,11 +42,6 @@ if IS_AIOSTREAM_INSTALLED:
         caught by a previous catcher.
         """
         if not wrap_secured_function and is_secured(func):
-            if func.__catcher__.on_error_return_always is not ERRORED:
-                raise ValueError(
-                    "The given function is already secured but does not return ERRORED in error case. "
-                    "If the secured function re-raises errors you can set wrap_secured_function=True"
-                )
             if (
                 on_success is not None
                 or on_error is not None
@@ -62,22 +58,32 @@ if IS_AIOSTREAM_INSTALLED:
             )
             secured_func = func
         else:
-            secured_func = decorator(  # type: ignore[assignment]
+            # pylint: disable=duplicate-code
+            secured_func = decorator_as_result(  # type: ignore[assignment]
                 on_success=on_success,
                 on_error=on_error,
                 on_finalize=on_finalize,
-                on_error_return_always=ERRORED,
                 suppress_recalling_on_error=suppress_recalling_on_error,
             )(
                 func  # type: ignore[arg-type]
             )
             # Ignore that T | ErroredType is not compatible with T. All ErroredType results are filtered out
             # in a subsequent step.
-        next_source: AsyncIterator[U] = aiostream.stream.map.raw(
+        results: AsyncIterator[ResultType[U]] = aiostream.stream.map.raw(
             source, secured_func, *more_sources, ordered=ordered, task_limit=task_limit  # type: ignore[arg-type]
         )
-        next_source = aiostream.stream.filter.raw(next_source, lambda result: result is not ERRORED)
-        return next_source
+        positive_results: AsyncIterator[PositiveResult[U]] = aiostream.stream.filter.raw(
+            results,  # type: ignore[arg-type]
+            # mypy can't successfully narrow the type here.
+            lambda result: not isinstance(result, NegativeResult),
+        )
+        result_values: AsyncIterator[U] = aiostream.stream.map.raw(
+            positive_results,
+            lambda result: (
+                result.result if isinstance(result, PositiveResult) else result  # type: ignore[arg-type, misc]
+            ),
+        )
+        return result_values
 
 else:
     from ._extra import _NotInstalled

--- a/unittests/test_callback_errors.py
+++ b/unittests/test_callback_errors.py
@@ -12,7 +12,7 @@ class TestCallbackErrors:
         def on_finalize_wrong_signature():
             pass
 
-        @error_handler.decorator(
+        @error_handler.decorator_as_result(
             on_success=on_success_callback, on_error=assert_not_called, on_finalize=on_finalize_wrong_signature
         )
         def func(hello: str) -> str:
@@ -36,7 +36,7 @@ class TestCallbackErrors:
         def on_error_callback(_: BaseException, __: str):
             raise ValueError("This is a test error")
 
-        @error_handler.decorator(
+        @error_handler.decorator_as_result(
             on_success=assert_not_called, on_error=on_error_callback, on_finalize=on_finalize_wrong_signature
         )
         def func(hello: str) -> str:

--- a/unittests/test_pipable_operators.py
+++ b/unittests/test_pipable_operators.py
@@ -63,22 +63,10 @@ class TestErrorHandlerPipableOperators:
         assert set(elements) == {1, 3, 5}
         assert errored_nums == {2, 4, 6}
 
-    async def test_secured_map_stream_double_secure_invalid_return_value(self):
-        op = stream.iterate([1, 2, 3, 4, 5, 6])
-
-        @error_handler.decorator(on_error_return_always=0)
-        def return_1(_: int) -> int:
-            return 1
-
-        with pytest.raises(ValueError) as error:
-            _ = error_handler.stream.map(op, return_1)
-
-        assert "The given function is already secured but does not return ERRORED in error case" in str(error.value)
-
     async def test_secured_map_stream_double_secure_invalid_arguments(self):
         op = stream.iterate([1, 2, 3, 4, 5, 6])
 
-        @error_handler.decorator()
+        @error_handler.decorator_as_result()
         def return_1(_: int) -> int:
             return 1
 
@@ -93,7 +81,7 @@ class TestErrorHandlerPipableOperators:
 
         op = stream.iterate([1, 2, 3, 4, 5, 6])
 
-        @error_handler.decorator(on_error=error_callback, on_success=success_callback)
+        @error_handler.decorator_as_result(on_error=error_callback, on_success=success_callback)
         def raise_for_even(num: int) -> int:
             if num % 2 == 0:
                 raise ValueError(num)


### PR DESCRIPTION
- Remove `ERRORED`
- Two decorators:
    - `decorator` leaves return type unchanged
    - `decorator_as_result` returns a result-object
- Use generic `Protocol`s with overloaded `__call__` signatures to better annotate the decorator
- Subclass cores `Catcher` for better typing for the context-manager
- Catch `BaseException` instead of `Exception`